### PR TITLE
Fixed bug where for-loop variable name was reused.

### DIFF
--- a/src/Expose/Manager.php
+++ b/src/Expose/Manager.php
@@ -196,7 +196,7 @@ class Manager
                     continue;
                 }
 
-                foreach ($this->getFilters() as $index => $filter) {
+                foreach ($this->getFilters() as $filter_index => $filter) {
                     if ($filter->execute($value) === true) {
                         $this->getLogger()->info(
                             'Match found on Filter ID '.$filter->getId(),


### PR DESCRIPTION
There are two loops, in the outer one $index is the name of the variable being examined and in the inner on $index was the number of the filter. This caused the wrong value to be passed to the Report constructor.

Suggesting alternate naming for the inner loop.
