### PR TITLE
Restoring Original Notification Functionality

### DIFF
--- a/src/Expose/Manager.php
+++ b/src/Expose/Manager.php
@@ -230,7 +230,7 @@ class Manager
      */
     protected function processFilters($value, $index, $path)
     {
-        $filterMatches = [];
+        $filterMatches = array();
         $filters = $this->getFilters();
         $filters->rewind();
         while($filters->valid() && !$this->impactLimitReached()) {

--- a/src/Expose/Manager.php
+++ b/src/Expose/Manager.php
@@ -210,7 +210,10 @@ class Manager
                 continue;
             }
 
-            $this->processFilters($value, $index, $path);
+            $filterMatches = array_merge(
+                $filterMatches,
+                $this->processFilters($value, $index, $path)
+            );
         }
 
         if ($cache !== null) {
@@ -227,12 +230,14 @@ class Manager
      */
     protected function processFilters($value, $index, $path)
     {
+        $filterMatches = [];
         $filters = $this->getFilters();
         $filters->rewind();
         while($filters->valid() && !$this->impactLimitReached()) {
             $filter = $filters->current();
             $filters->next();
             if ($filter->execute($value) === true) {
+                $filterMatches[] = $filter;
                 $this->getLogger()->info(
                     'Match found on Filter ID '.$filter->getId(),
                     array($filter->toArray())
@@ -245,6 +250,7 @@ class Manager
                 $this->impact += $filter->getImpact();
             }
         }
+        return $filterMatches;
     }
 
     /**

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -383,7 +383,7 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
         $manager_mock
            ->expects($this->once())
            ->method('sendNotification')
-           ->with([$filter]);
+           ->with(array($filter));
 
         $manager_mock->setThreshold(7);
         $manager_mock->run(array('test' => 'test'), false, true);

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -382,7 +382,8 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
 
         $manager_mock
            ->expects($this->once())
-           ->method('sendNotification');
+           ->method('sendNotification')
+           ->with([$filter]);
 
         $manager_mock->setThreshold(7);
         $manager_mock->run(array('test' => 'test'), false, true);


### PR DESCRIPTION
Notification Functionality was broken/lost with the conversion to recursive filters checking. $filterMatches was updated on the recursion, but not on the process filters. As a result, all launches sent an empty array to the sendNotifications method. These two changes A) Restore the documented notifications system and B) Update the testing to properly ensure that a filter is sent to the notification system.


Restoring Original Filter Match Functionality To Fix Notifications Sending
Updating Test To Verify Notification Called With Filters