### PR TITLE
convertFromJSCharcode: only include '-' in regex, not the range

### DIFF
--- a/src/Expose/Converter/ConvertJS.php
+++ b/src/Expose/Converter/ConvertJS.php
@@ -19,7 +19,7 @@ class ConvertJS
     {
         $matches = array();
         // check if value matches typical charCode pattern
-        if (preg_match_all('/(?:[\d+-=\/\* ]+(?:\s?,\s?[\d+-=\/\* ]+)){4,}/ms', $value, $matches)) {
+        if (preg_match_all('/(?:[\d+\-=\/\* ]+(?:\s?,\s?[\d+\-=\/\* ]+)){4,}/ms', $value, $matches)) {
             $converted = '';
             $string    = implode(',', $matches[0]);
             $string    = preg_replace('/\s/', '', $string);


### PR DESCRIPTION
Escape '-' character so that we don't include other chars in regex. Props to @dustingraham for finding this. Fixes #51