### PR TITLE
Remove unnecessary constructor

### DIFF
--- a/src/Expose/Log.php
+++ b/src/Expose/Log.php
@@ -21,18 +21,6 @@ abstract class Log implements LoggerInterface
 	public abstract function log($level, $message, array $context = array());
 
     /**
-     * Init the object and connect if string is given
-     * 
-     * @param object $connectString Connection string to logger instance
-     */
-	public function __construct($connectString = null)
-	{
-		if ($connectString !== null) {
-			$this->connect($connectString);
-		}
-	}
-
-    /**
      * Set the logger object instance
      *
      * @param object $logger Logger instance


### PR DESCRIPTION
This is not necessary to define a constructor in this abstract class.

Furthermore the constructor calls a method `connect` which doesn't exist.